### PR TITLE
Use capital M for margin

### DIFF
--- a/html/uncommented.html
+++ b/html/uncommented.html
@@ -10,12 +10,12 @@
     <style type="text/css">
         html {
             padding: 0;
-            margin: 0;
+            Margin: 0;
         }
         body {
             background-color: #444444;
             padding:0;
-            margin:0;
+            Margin:0;
             -webkit-text-size-adjust: 100%;
             -ms-text-size-adjust: 100%;
         }
@@ -38,7 +38,7 @@
           line-height: 100%;
         }
         #backgroundTable {
-          margin: 0;
+          Margin: 0;
           padding: 0;
           width: 100%;
           line-height: 100%;
@@ -156,11 +156,11 @@
         }
 
         @media screen and (min-width:1px) {
-            .flybrid > tbody > tr > th { margin: -1px !important; }
+            .flybrid > tbody > tr > th { Margin: -1px !important; }
         }
 
         @media screen and (min-width:1px) and (max-width:3000px) {
-            .flybrid > tbody > tr > th { margin: 0 !important; }
+            .flybrid > tbody > tr > th { Margin: 0 !important; }
         }
     </style>
 <!--[if gte mso 9]><xml>


### PR DESCRIPTION
Outlook.com still strips lowercase margin declarations; capitalizing the M in Margin is a workaround.

Reference: http://webdesign.tutsplus.com/tutorials/creating-a-future-proof-responsive-email-without-media-queries--cms-23919
